### PR TITLE
修复点击右上角 Edit in GitHub 链接跳转错误

### DIFF
--- a/docs/更新日志.md
+++ b/docs/更新日志.md
@@ -6,6 +6,14 @@ abbrlink: 179nqpxt
 
 `create-react-doc` 严格遵循 [Semantic Versioning 2.0.0](http://semver.org/lang/zh-CN/) 语义化版本规范。
 
+### 1.5.2
+
+`2021-10-19`
+
+- **Fix**
+
+  - 🐞 修复点击右上角 `Edit in GitHub` 链接跳转错误的问题。[issue](https://github.com/MuYunyun/create-react-doc/issues/205)。
+
 ### 1.5.1
 
 `2021-10-19`

--- a/packages/crd-seed/layout/index.js
+++ b/packages/crd-seed/layout/index.js
@@ -136,23 +136,18 @@ function BasicLayout({
    * such as edit in github and so on.
    */
   const renderPageHeader = () => {
-    console.log('routeData', routeData)
-    console.log('menuSource', menuSource)
     const curMenuSource = routeData.filter(r => {
       if (r.props.type === 'directory') return false
       return pathname.indexOf(r.mdconf.abbrlink) > -1 || decodeURIComponent(pathname).indexOf(r.path) > -1
     })
-    const editPathName = curMenuSource[0] && curMenuSource[0].path
-    console.log('curMenuSource', curMenuSource)
-    console.log('a link', `https://github.com/${user}/${repo
-      }/edit/${branch}${editPathName}.md`)
+    const editPathName = curMenuSource[0] && curMenuSource[0].props.path
     return (
       <div className={cx(styles.pageHeader)}>
         {user && repo ? (
           <a
             href={`https://github.com/${user}/${
               repo
-            }/edit/${branch}${editPathName}.md`}
+            }/edit/${branch}${editPathName}`}
             target="_blank"
           >
             <Icon className={cx(styles.icon)} type="edit" size={13} />


### PR DESCRIPTION
### 1.5.2

`2021-10-19`

- **Fix**

  - 🐞 修复点击右上角 `Edit in GitHub` 链接跳转错误的问题。[issue](https://github.com/MuYunyun/create-react-doc/issues/205)。