### PR TITLE
fix: using hydrate instead of hydrateRoot temporarily

### DIFF
--- a/packages/crd-scripts/src/web/index.js
+++ b/packages/crd-scripts/src/web/index.js
@@ -1,5 +1,6 @@
+import { hydrate } from 'react-dom'
 import { renderToString } from 'react-dom/server';
-import { hydrateRoot } from 'react-dom/client'
+// import { hydrateRoot } from 'react-dom/client'
 import '@babel/polyfill'
 import { ifDev, ifPrerender } from 'crd-client-utils'
 import RouterRoot from './Router'
@@ -7,17 +8,27 @@ import RouterRoot from './Router'
 if (ifDev) {
   // dev render
   document.getElementById('root').innerHTML = renderToString(<RouterRoot />)
-  hydrateRoot(
-    document.getElementById('root'),
+  hydrate(
     <RouterRoot />,
+    document.getElementById('root'),
   )
+  // hydrateRoot(
+  //   document.getElementById('root'),
+  //   <RouterRoot />,
+  // )
 } else if (ifPrerender) {
   // prerender
   document.getElementById('root').innerHTML = renderToString(<RouterRoot />)
 } else {
   // prod render:
-  hydrateRoot(
-    document.getElementById('root'),
+  // It'll cause some [unkown error](https://github.com/MuYunyun/create-react-doc/issues/278) using hydrateRoot here.
+  // So still using hydrate temporarily.
+  hydrate(
     <RouterRoot />,
+    document.getElementById('root'),
   )
+  // hydrateRoot(
+  //   document.getElementById('root'),
+  //   <RouterRoot />,
+  // )
 }


### PR DESCRIPTION
It'll cause some [unkown error](https://github.com/MuYunyun/create-react-doc/issues/278) using hydrateRoot here. So still using hydrate temporarily.

